### PR TITLE
🐞Bug : Fixed the JSX error in the typography file and also included '…

### DIFF
--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react';
+
 import { cn } from '@/lib/utils';
 
 // Reusable helper to create components with consistent structure
 const createComponent = <T extends HTMLElement>(
-  tag: keyof JSX.IntrinsicElements,
+  tag: keyof React.JSX.IntrinsicElements,
   defaultClassName: string,
   displayName: string
 ) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
 		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
 		"strict": true /* Enable all strict type-checking options. */,
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */,
-		"jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+		"jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+		"baseUrl": "./src",
+		"paths": {
+			"@/*": ["*"]
+		}
 	}
 }


### PR DESCRIPTION
## 🛠 Fix: Cannot Find Namespace 'JSX' TypeScript Error

### 📄 Problem

In `typography.tsx`, the following TypeScript error was occurring:


This has become a more common issue with the release of **React 19** and **TypeScript 5.7+**, due to changes in how the `JSX` namespace is defined and resolved.

---

### ✅ Solution

I fixed this issue by **explicitly referencing `React.JSX.Element`** instead of `JSX.Element`.

**Before:**
```ts
const createComponent = <T extends HTMLElement>(
  tag: keyof JSX.IntrinsicElements,
  defaultClassName: string,
  displayName: string
) => {
  const Component = forwardRef<T, React.HTMLAttributes<T>>((props, ref) => {
    return React.createElement(
      tag,
      { ...props, ref, className: cn(defaultClassName, props.className) },
      props.children
    );
  });
  Component.displayName = displayName;
  return Component;
};
```
**After:**
```ts
const createComponent = <T extends HTMLElement>(
  tag: keyof React.JSX.IntrinsicElements,
  defaultClassName: string,
  displayName: string
) => {
  const Component = forwardRef<T, React.HTMLAttributes<T>>((props, ref) => {
    return React.createElement(
      tag,
      { ...props, ref, className: cn(defaultClassName, props.className) },
      props.children
    );
  });
  Component.displayName = displayName;
  return Component;
};
```
💡 Why this approach?
Although we can resolve this globally via tsconfig.json using:
```ts
"jsx": "react-jsx"
```
many developers might copy-paste this file into their own projects where the tsconfig.json may not be properly configured.

To keep it small-scale, portable, and error-free by default, using React.JSX directly inside the file ensures broader compatibility across setups.

📷 Screenshots (Before & After)

**Before changes code with Errors showing in the IDE**
![Screenshot 2025-06-05 183930](https://github.com/user-attachments/assets/3d90af8f-2e66-45bb-af45-56b85ae3c5d7)

**After the changes, all errors resolved**
![Screenshot 2025-06-05 183954](https://github.com/user-attachments/assets/e34dd936-16f8-4159-a327-beb7a33488d0)
